### PR TITLE
Set up the Conda environment with setup-micromamba

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     name: Run pipeline
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: mamba-org/setup-micromamba@v1
         with:
             micromamba-version: '1.3.1-0'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,15 +8,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Create Conda environment
-        run: |
-          conda install -c conda-forge mamba
-          source $CONDA/etc/profile.d/conda.sh
-          mamba env create --quiet -n testenv -f environment.yml
-          mamba install --quiet -n testenv -y pytest
-      - name: Run pipeline
-        run: |
-          source $CONDA/etc/profile.d/conda.sh
-          conda activate testenv
-          pip install .
-          ./test.sh
+      - uses: mamba-org/setup-micromamba@v1
+        with:
+            micromamba-version: '1.3.1-0'
+            environment-file: environment.yml
+            environment-name: testenv
+            create-args: pytest
+            init-shell: bash
+            cache-environment: true
+      - name: Install pipeline
+        shell: bash -el {0}
+        run: pip install .
+      - name: Run tests
+        shell: bash -el {0}
+        run: ./test.sh


### PR DESCRIPTION
This has a couple of advantages over the current method:
- The step of installing mamba can be dropped as micromamba is a replacement for mamba
- Creating the environment takes 2.5 instead of 4 minutes.
- ... except when the cache can be used, and then it only takes 20 seconds.

So this should more than make up for the test slowdown that #168 introduces.

Marking as draft as I need to
- [ ] rebase this on main as soon as the other PRs are merged
- [ ] wait until the openjdk issue is solved somehow
- [ ] remove the last "test caching" commit which only exists to show that caching works